### PR TITLE
Use v02 staging URL, add `CERT_ID_PREFIX` env variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,5 +21,7 @@ This container will attempt to renew certificates once a month. The container wi
 ### Optional Variables
 
 * `USE_STAGING_SERVER` if set, We'll use the Let's Encrypt staging server. This wont issue usable certs, but will allow you to use / reuse the same domains list. *Warning* if you re-create this container more than 5 times in a month without a persistent volume, you will be rate limited and you wont be able to get more certificates until the next month.
+* `CERT_ID_PREFIX` will create new certificates with this string followed by `cert-${random string}`
+
 
 Leave the docker container running, and it will attempt to update the cert once a month and remove the older cert once the new cert is installed.

--- a/init.sh
+++ b/init.sh
@@ -16,7 +16,7 @@ KEY=$(ls -1 /root/.lego/certificates | grep key\$)
 cat /root/.lego/certificates/$CERT /root/.lego/certificates/$CERT_ISSUER > cert.crt
 
 # Create name for new certificate in gcloud
-CERT_ID=$(cat /dev/urandom | tr -dc 'a-z' | fold -w 16 | head -n 1)-cert
+CERT_ID=${CERT_ID_PREFIX}cert-$(cat /dev/urandom | tr -dc 'a-z' | fold -w 16 | head -n 1)
 OLD_CERT_ID=$(./google-cloud-sdk/bin/gcloud -q compute target-https-proxies list --filter "name=${TARGET_PROXY}" | sed -n 2p | awk '{print $2}')
 
 # Generate new gcloud certificate and attach to https proxy

--- a/init.sh
+++ b/init.sh
@@ -3,7 +3,7 @@
 set -e
 
 # Set Staging server if parameter is set
-USE_STAGING_SERVER="${USE_STAGING_SERVER+--server=https://acme-staging.api.letsencrypt.org/directory}"
+USE_STAGING_SERVER="${USE_STAGING_SERVER+--server=https://acme-staging-v02.api.letsencrypt.org/directory}"
 
 # On Startup
 # Lets Encrypt Initialize

--- a/monthly.sh
+++ b/monthly.sh
@@ -4,7 +4,7 @@ set -e
 
 
 # Set Staging server if parameter is set
-USE_STAGING_SERVER="${USE_STAGING_SERVER+--server=https://acme-staging.api.letsencrypt.org/directory}"
+USE_STAGING_SERVER="${USE_STAGING_SERVER+--server=https://acme-staging-v02.api.letsencrypt.org/directory}"
 
 # Lets Encrypt Renew
 ./lego $USE_STAGING_SERVER --dns-timeout 30 -k rsa2048 -m $LETSENCRYPT_EMAIL -dns gcloud $DOMAINS_LIST -a renew
@@ -16,7 +16,7 @@ KEY=$(ls -1 /root/.lego/certificates | grep key\$)
 cat /root/.lego/certificates/$CERT /root/.lego/certificates/$CERT_ISSUER > cert.crt
 
 # Create name for new certificate in gcloud
-CERT_ID=$(cat /dev/urandom | tr -dc 'a-z' | fold -w 16 | head -n 1)-cert
+CERT_ID=${CERT_ID_PREFIX}cert-$(cat /dev/urandom | tr -dc 'a-z' | fold -w 16 | head -n 1)
 OLD_CERT_ID=$(./google-cloud-sdk/bin/gcloud -q compute target-https-proxies list --filter "name=${TARGET_PROXY}" | sed -n 2p | awk '{print $2}')
 
 # Generate new gcloud certificate and attach to https proxy


### PR DESCRIPTION
* Fixes the Let's Encrypt staging url to use the v02 API (was failing before)
* Introduces optional `CERT_ID_PREFIX`, which lets users easily identify what an SSL cert is used for